### PR TITLE
Add "drop table if exists" for exchange table

### DIFF
--- a/server/init.sql
+++ b/server/init.sql
@@ -5,6 +5,7 @@ drop table if exists transactions;
 drop table if exists accounts_transactions;
 drop table if exists notifications;
 drop table if exists users_notifications;
+drop table if exists exchange;
 
 create table users (
 	id integer primary key autoincrement,


### PR DESCRIPTION
The initialization script is only called if no database exists, so this
shouldn't matter since there would be nothing to drop,
but consistency is nice.